### PR TITLE
Fix Eigen header include, set C++ standard to C++14

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,7 +52,7 @@ add_executable(vchsm
 )
 
 # C++ 11
-target_compile_features(vchsm PUBLIC cxx_std_11)
+target_compile_features(vchsm PUBLIC cxx_std_14)
 set_target_properties(vchsm PROPERTIES CXX_EXTENSIONS OFF)
 
 # include directories

--- a/CppAlgo/src/stochasticanalysis.h
+++ b/CppAlgo/src/stochasticanalysis.h
@@ -1,5 +1,5 @@
 #pragma once
-#include <Eigen/dense>
+#include <Eigen/Dense>
 #include "PicosElement.h"
 #include <vector>
 #include "types.h"


### PR DESCRIPTION
Setting C++ standard to C++14 was necessary, as (at least with g++-8.3) deduced return types are only available with `-std=c++14` or `-std=gnu++14`.